### PR TITLE
fix(ci): pass valid commitlint ranges on main

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -36,12 +36,12 @@ jobs:
             LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
             if [ -z "$LAST_TAG" ]; then
               echo "No previous tags found, checking all commits"
-              RANGE=HEAD~10..HEAD
+              FROM=HEAD~10
             else
-              RANGE=$LAST_TAG..HEAD
+              FROM=$LAST_TAG
             fi
-            echo "Commit range: $RANGE"
-            npx commitlint --from=$RANGE --to=HEAD --verbose
+            echo "Commit range: $FROM..HEAD"
+            npx commitlint --from=$FROM --to=HEAD --verbose
           else
             echo "Checking PR commits..."
             npx commitlint --from=origin/${{ github.base_ref }} --to=HEAD --verbose


### PR DESCRIPTION
## Summary
- fix the main-branch commitlint workflow so it passes valid `--from` / `--to` revisions to commitlint
- avoid generating an invalid range like `HEAD~10..HEAD..HEAD` when no previous tag exists

## Why this is needed
- the previous post-merge workflow fix PR was already merged
- this branch received one follow-up commit afterwards, so a new PR is required to bring that fix into `main`

## Testing
- `npx -p @commitlint/cli -p @commitlint/config-conventional commitlint --config commitlint.config.cjs --from HEAD~3 --to HEAD --verbose`
