### PR TITLE
fix(ci): lint only the latest main commit

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -32,16 +32,8 @@ jobs:
       - name: Lint commits
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
-            echo "Checking commits since last tag..."
-            LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
-            if [ -z "$LAST_TAG" ]; then
-              echo "No previous tags found, checking all commits"
-              FROM=HEAD~10
-            else
-              FROM=$LAST_TAG
-            fi
-            echo "Commit range: $FROM..HEAD"
-            npx commitlint --from=$FROM --to=HEAD --verbose
+            echo "Checking the latest commit on main..."
+            git log -1 --pretty=%B | npx commitlint --verbose
           else
             echo "Checking PR commits..."
             npx commitlint --from=origin/${{ github.base_ref }} --to=HEAD --verbose


### PR DESCRIPTION
## Summary
- simplify the push-to-main commitlint path to lint only the latest merge commit message
- keep the stricter commit range validation on pull requests, where the branch commit history is still reviewed before merge

## Why this is needed
- main currently contains older historical commits that predate the stricter commitlint rules
- linting the whole merged range on every push keeps failing even after recent fixes

## Testing
- `git log -1 --pretty=%B | npx -p @commitlint/cli -p @commitlint/config-conventional commitlint --config commitlint.config.cjs --verbose`
