### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/initial-v0.0.1.md
+++ b/.changeset/initial-v0.0.1.md
@@ -1,9 +1,0 @@
----
-"@giopic/core": minor
-"@giopic/lsky-plugin": minor
-"@giopic/lskypro-plugin": minor
-"@giopic/s3-plugin": minor
----
-
-Initial release v0.0.1 - GioPic plugin ecosystem
-

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @giopic/core
+
+## 0.1.0
+
+### Minor Changes
+
+- [#18](https://github.com/isYangs/GioPic/pull/18) [`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf) Thanks [@isYangs](https://github.com/isYangs)! - Initial release v0.0.1 - GioPic plugin ecosystem

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@giopic/core",
   "type": "module",
-  "version": "0.0.2-beta.1",
+  "version": "0.1.0",
   "description": "GioPic 核心工具包，提供插件所需的通用功能",
   "author": "isYangs",
   "license": "AGPL-3.0",

--- a/packages/lsky-plugin/CHANGELOG.md
+++ b/packages/lsky-plugin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @giopic/lsky-plugin
+
+## 1.0.0
+
+### Minor Changes
+
+- [#18](https://github.com/isYangs/GioPic/pull/18) [`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf) Thanks [@isYangs](https://github.com/isYangs)! - Initial release v0.0.1 - GioPic plugin ecosystem
+
+### Patch Changes
+
+- Updated dependencies [[`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf)]:
+  - @giopic/core@0.1.0

--- a/packages/lsky-plugin/package.json
+++ b/packages/lsky-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@giopic/lsky-plugin",
   "type": "module",
-  "version": "0.0.2-beta.1",
+  "version": "1.0.0",
   "description": "兰空插件，同时支持社区版和企业版v1",
   "author": "isYangs",
   "license": "AGPL-3.0",

--- a/packages/lskypro-plugin/CHANGELOG.md
+++ b/packages/lskypro-plugin/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @giopic/lskypro-plugin
+
+## 1.0.0
+
+### Minor Changes
+
+- [#18](https://github.com/isYangs/GioPic/pull/18) [`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf) Thanks [@isYangs](https://github.com/isYangs)! - Initial release v0.0.1 - GioPic plugin ecosystem
+
+### Patch Changes
+
+- Updated dependencies [[`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf)]:
+  - @giopic/core@0.1.0

--- a/packages/lskypro-plugin/package.json
+++ b/packages/lskypro-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@giopic/lskypro-plugin",
   "type": "module",
-  "version": "0.0.2-beta.1",
+  "version": "1.0.0",
   "description": "兰空插件，仅支持企业版v2",
   "author": "isYangs",
   "license": "AGPL-3.0",

--- a/packages/s3-plugin/CHANGELOG.md
+++ b/packages/s3-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @giopic/s3-plugin
+
+## 0.1.0
+
+### Minor Changes
+
+- [#18](https://github.com/isYangs/GioPic/pull/18) [`d6bf53c`](https://github.com/isYangs/GioPic/commit/d6bf53ccb9109b349a6083fda70f928d752ad2bf) Thanks [@isYangs](https://github.com/isYangs)! - Initial release v0.0.1 - GioPic plugin ecosystem

--- a/packages/s3-plugin/package.json
+++ b/packages/s3-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@giopic/s3-plugin",
   "type": "module",
-  "version": "0.0.2-beta.1",
+  "version": "0.1.0",
   "description": "兼容S3协议的存储服务插件(如AWS/腾讯云/阿里云)",
   "author": "isYangs",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- apply changesets versioning for the plugin packages on `main`
- remove the consumed changeset entry
- generate package changelogs for the released plugin packages

## Notes
- this branch was already prepared by the `Release Packages` workflow
- the workflow failed only when trying to create the pull request automatically
