### PR TITLE
fix(ci): execute package publish script with bash

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -61,7 +61,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm exec node scripts/publish-packages.sh
+          publish: bash scripts/publish-packages.sh
           version: pnpm changeset:version
           commit: 'chore: version packages'
           title: 'chore: version packages'


### PR DESCRIPTION
## Summary
- fix the changesets release workflow so it executes `scripts/publish-packages.sh` with `bash`
- avoid treating the shell script as a Node.js module during the `Release Packages` publish step

## Why this is needed
- the latest `Release Packages` run reached the publish phase but failed with `ERR_UNKNOWN_FILE_EXTENSION` for `.sh`
- the version PR flow is already working; this unblocks the actual package publish step on `main`
