### PR TITLE
fix(build): explicitly externalize node sqlite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const appVersion = pkg.version
 const external = [
   'electron',
+  'sqlite',
+  'node:sqlite',
   ...builtinModules,
   ...builtinModules.map(moduleName => `node:${moduleName}`),
   ...Object.keys('dependencies' in pkg ? pkg.dependencies : {}),


### PR DESCRIPTION
## Summary

- Explicitly externalize `sqlite` and `node:sqlite` for Electron Vite builds.
- Fix GitHub Release workflow runners where Node's builtin module list may not include sqlite, causing `DatabaseSync` to be resolved as a browser external.

## Validation

- `pnpm lint`
- `pnpm run build:app`