### PR TITLE
fix(ci): disable electron-builder auto publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,11 +83,11 @@ jobs:
 
       - name: Build Mac (ad-hoc)
         if: matrix.os == 'macos-latest'
-        run: pnpm run build:mac
+        run: pnpm run build:app && pnpm exec electron-builder --mac --publish=never
 
       - name: Build Windows (unsigned)
         if: matrix.os == 'windows-latest'
-        run: pnpm run build:win
+        run: pnpm run build:app && pnpm exec electron-builder --win --publish=never
 
       - name: Cleanup Mac artifacts
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## Summary

- Build desktop installers with `electron-builder --publish=never` in the Release workflow.
- Keep GitHub Release creation owned by `softprops/action-gh-release` after artifacts are uploaded.

## Validation

- `pnpm lint`
- `pnpm run build:app`