### PR TITLE
fix(ci): repair desktop release metadata

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -11,20 +11,20 @@
 
 | 类型 / Type | x64 | arm64 |
 |-------------|-----|-------|
-| 安装版 / Installer | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{tag}}-x64-setup.exe) | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{tag}}-arm64-setup.exe) |
+| 安装版 / Installer | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{version}}-x64-setup.exe) | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{version}}-arm64-setup.exe) |
 
 ### macOS
 
 | 类型 / Type | Intel (x64) | Apple Silicon (arm64) |
 |-------------|-------------|---------------------|
-| DMG | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{tag}}-x64.dmg) | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{tag}}-arm64.dmg) |
+| DMG | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{version}}-x64.dmg) | [下载 / Download](https://github.com/isYangs/GioPic/releases/download/{{tag}}/GioPic-{{version}}-arm64.dmg) |
 
 ---
 
 ## 🔗 相关链接 / Resources
 
 - [源代码 / Source Code](https://github.com/isYangs/GioPic/archive/refs/tags/{{tag}}.zip)
-- [完整变更记录 / Full Changelog](https://github.com/isYangs/GioPic/compare/{{prevTag}}...{{tag}})
+- [完整变更记录 / Full Changelog]({{compareUrl}})
 - [问题反馈 / Report an Issue](https://github.com/isYangs/GioPic/issues)
 
 ---

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,7 @@ jobs:
         run: |
           Get-ChildItem -Path release -Recurse -File |
             Where-Object {
-              $_.Name -notlike '*.exe' -and
-              $_.Name -notlike '*.zip' -and
+              $_.Name -notlike 'GioPic-*-setup.exe' -and
               $_.Name -notlike 'latest*.yml'
             } |
             Remove-Item -Force
@@ -137,6 +136,16 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Ensure release tag exists
+        shell: bash
+        run: |
+          TAG="${{ steps.get-tag.outputs.tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            exit 0
+          fi
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
@@ -151,11 +160,20 @@ jobs:
         id: generate-body
         run: |
           TAG="${{ steps.get-tag.outputs.tag }}"
+          VERSION="${TAG#v}"
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          if [ -n "$PREV_TAG" ]; then
+            COMPARE_URL="https://github.com/isYangs/GioPic/compare/$PREV_TAG...$TAG"
+          else
+            COMPARE_URL="https://github.com/isYangs/GioPic/commits/$TAG"
+          fi
 
           BODY=$(cat .github/release-template.md)
           BODY="${BODY//\{\{tag\}\}/$TAG}"
+          BODY="${BODY//\{\{version\}\}/$VERSION}"
           BODY="${BODY//\{\{prevTag\}\}/$PREV_TAG}"
+          BODY="${BODY//\{\{compareUrl\}\}/$COMPARE_URL}"
 
           {
             echo "body<<EOF"


### PR DESCRIPTION
## Summary
- create the requested release tag during manual desktop release runs so GitHub Releases are attached to `v*` tags instead of `untagged-*`
- fix desktop release template download links to use artifact names without the leading `v`
- filter Windows release uploads to installers/update metadata only, avoiding unpacked helper executables

## Validation
- `git diff --check`