### PR TITLE
fix(build): include axios proxy runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "p-limit": "^7.3.0",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate-2": "^2.0.32",
+    "proxy-from-env": "^2.1.0",
     "radash": "^12.1.1",
     "sharp": "^0.34.5",
     "vue": "^3.5.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       pinia-plugin-persistedstate-2:
         specifier: ^2.0.32
         version: 2.0.32(pinia@3.0.4(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3)))
+      proxy-from-env:
+        specifier: ^2.1.0
+        version: 2.1.0
       radash:
         specifier: ^12.1.1
         version: 12.1.1


### PR DESCRIPTION
## Summary
- promote `proxy-from-env` to a direct app dependency so Electron packaging includes axios' runtime proxy helper inside `app.asar`

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run build:plugins && pnpm run typecheck`
- `pnpm run build:app && pnpm exec electron-builder --mac --dir --publish=never`
- verified `release/0.0.1/mac-arm64/GioPic.app/Contents/Resources/app.asar` contains `/node_modules/proxy-from-env`