### PR TITLE
fix(build): use asar API in runtime verifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@antfu/eslint-config": "^4.13.1",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
+    "@electron/asar": "^3.4.1",
     "@iconify/json": "^2.2.458",
     "@iconify/vue": "^5.0.0",
     "@playwright/test": "^1.54.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@24.12.0)
+      '@electron/asar':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@iconify/json':
         specifier: ^2.2.458
         version: 2.2.458

--- a/scripts/verify-packaged-runtime-deps.mjs
+++ b/scripts/verify-packaged-runtime-deps.mjs
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { extractAll } from '@electron/asar'
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const releaseDir = path.join(rootDir, 'release')
@@ -61,14 +61,11 @@ function packageJsonPath(extractedDir, packageName) {
 }
 
 function extractAsar(asarPath, destination) {
-  const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const result = spawnSync(pnpm, ['exec', 'asar', 'extract', asarPath, destination], {
-    cwd: rootDir,
-    stdio: 'inherit',
-  })
-
-  if (result.status !== 0) {
-    throw new Error(`Failed to extract ${path.relative(rootDir, asarPath)}`)
+  try {
+    extractAll(asarPath, destination)
+  }
+  catch (error) {
+    throw new Error(`Failed to extract ${path.relative(rootDir, asarPath)}`, { cause: error })
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch the packaged-runtime verifier from spawning `pnpm exec asar extract` to using the `@electron/asar` Node API directly.
- Add `@electron/asar` as an explicit dev dependency so the Release workflow does not depend on transitive CLI resolution.

## Root Cause
- The first verifier fix passed on macOS, but Windows failed while extracting `win-arm64-unpacked/resources/app.asar` through the spawned asar CLI.
- Using the Node API avoids Windows shell/CLI path behavior and keeps the verifier cross-platform.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run verify:package-runtime`
- `pnpm run lint`