### PR TITLE
chore(e2e): format global setup path resolution

### DIFF
--- a/e2e/support/global-setup.ts
+++ b/e2e/support/global-setup.ts
@@ -3,7 +3,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
 const mainEntry = path.join(repoRoot, 'dist-electron/main/index.js')
 const rendererEntry = path.join(repoRoot, 'dist/index.html')
 


### PR DESCRIPTION
## Summary
- Commit the pending E2E global setup formatting change.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build:plugins && pnpm run typecheck && pnpm run test:unit:run`
- `git diff --check`
- Checked changed files for the string `codex`.
